### PR TITLE
Use cron to execute the script only once per day

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,23 @@
 FROM python:3.9.5-slim-buster
 
-ARG WITHINGS_SYNC_VERSION=v3.2.0
+ARG WITHINGS_SYNC_COMMIT=9153773e4e2ad32ce05f4d2a87c6eb9e8ed80ae2
 ARG TINI_VERSION=v0.19.0
 ARG GIT_VERSION=1:2.20.1-2+deb10u3
-
-ADD "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini" /tini
-RUN chmod +x /tini
-
-COPY entrypoint.sh /entrypoint.sh
+ARG CRON_VERSION=3.0pl1-134+deb10u1
+ARG CURL_VERSION=7.64.0-4+deb10u2
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git="${GIT_VERSION}" && \
+    apt-get install -y --no-install-recommends git="${GIT_VERSION}" cron="${CRON_VERSION}" curl="${CURL_VERSION}" && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    pip install --no-cache-dir git+https://github.com/jaroslawhartman/withings-sync.git@"${WITHINGS_SYNC_VERSION}"
+    curl -sL "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini" -o /tini && \
+    chmod +x /tini && \
+    pip install --no-cache-dir git+https://github.com/jaroslawhartman/withings-sync.git@"${WITHINGS_SYNC_COMMIT}"
+
+COPY entrypoint.sh /entrypoint.sh
+COPY withings-sync /etc/cron.d/withings-sync
+
+RUN chmod 0644 /etc/cron.d/withings-sync
 
 ENTRYPOINT ["/tini", "--"]
-
 CMD ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,5 @@ For more information visit [https://github.com/jaroslawhartman/withings-sync#usa
 
 ## Configuration
 
-There is a wrapper around `withings-sync` to run it every `900` seconds.
-
-To change this value start the docker container with `-e SLEEP=<YOUR_SLEEP_TIME>`.
+There is cron config to run `withings-sync` every day at 10.
+To change this time you need to edit the `withings-sync` file.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,18 +2,19 @@
 
 set -eu
 
-sleep="${SLEEP:-900}"
-verbose="${VERBOSE:-false}"
+# trap ctrl-c and call ctrl_c()
+trap ctrl_c INT
 
-if [[ ${verbose} == "true" ]]; then
-    args="-v"
-    echo "sleep value: ${sleep}"
-    echo "withings-sync arguments: ${args}"
-fi
+function ctrl_c() {
+        echo "Trapped CTRL-C, exiting"
+        exit 0
+}
 
+echo "Starting cron..."
+/etc/init.d/cron start
 
-while true; do
-    withings-sync "${args}"
-    echo "Command completed. Sleeping ${sleep} seconds..."
-    sleep "${sleep}"
+while true;
+do
+    echo "Container up and running..."
+    sleep 86400
 done

--- a/withings-sync
+++ b/withings-sync
@@ -1,0 +1,1 @@
+0 10 * * * root /usr/local/bin/withings-sync >> /var/log/cron-withings-sync.log 2>&1


### PR DESCRIPTION
- Pin to specific withings-sync commit
- Use cron to run once per day