### PR TITLE
Save env vars for cron

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,9 @@ function ctrl_c() {
 echo "Starting cron..."
 /etc/init.d/cron start
 
+echo "Setting environment variables for cron..."
+printenv | sed 's/^\(.*\)$/export \1/g' > /root/cron_env.sh
+
 while true;
 do
     echo "Container up and running..."

--- a/withings-sync
+++ b/withings-sync
@@ -1,1 +1,1 @@
-0 10 * * * root /usr/local/bin/withings-sync >> /var/log/cron-withings-sync.log 2>&1
+0 10 * * * root . /root/cron_env.sh; /usr/local/bin/withings-sync -v >> /var/log/cron-withings-sync.log 2>&1


### PR DESCRIPTION
- Expose containers environment variables to crontab jobs
- Use verbose mode by default