### PR TITLE
Add missing setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     curl -sL "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini" -o /tini && \
     chmod +x /tini && \
+    pip install --no-cache-dir setuptools && \
     pip install --no-cache-dir git+https://github.com/jaroslawhartman/withings-sync.git@"${WITHINGS_SYNC_COMMIT}"
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Fix
```
Traceback (most recent call last):
  File "/usr/local/bin/withings-sync", line 5, in <module>
    from withings_sync.sync import main
  File "/usr/local/lib/python3.13/site-packages/withings_sync/sync.py", line 18, in <module>
    from withings_sync.withings2 import WithingsAccount
  File "/usr/local/lib/python3.13/site-packages/withings_sync/withings2.py", line 7, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```