### PR TITLE
Revert to python 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim-bookworm
+FROM python:3.13-slim-bookworm
 
 ARG WITHINGS_SYNC_COMMIT=14b4ac90454948d80192bbfb6493842c7490d542
 ARG TINI_VERSION=v0.19.0


### PR DESCRIPTION
We can't use python 3.14 yet as per https://github.com/matin/garth/issues/144 and https://github.com/tcgoetz/GarminDB/issues/293