### PR TITLE
Add Renovate custom managers for Dockerfile dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,25 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^Dockerfile$"],
+      "matchStrings": [
+        "ARG TINI_VERSION=(?<currentValue>v\\S+)"
+      ],
+      "depNameTemplate": "krallin/tini",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^Dockerfile$"],
+      "matchStrings": [
+        "# withings-sync (?<currentValue>v\\S+)\\nARG WITHINGS_SYNC_COMMIT=(?<currentDigest>[a-f0-9]+)"
+      ],
+      "depNameTemplate": "jaroslawhartman/withings-sync",
+      "datasourceTemplate": "github-tags"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- The existing `config:recommended` preset already covers **GitHub Actions** (`github-actions` manager) and **Dockerfile base images** (`dockerfile` manager), but misses two `ARG`-based version pins.
- Add `customManagers` (regex) for:
  - **`krallin/tini`** — tracks `TINI_VERSION` ARG against `github-releases`
  - **`jaroslawhartman/withings-sync`** — tracks `WITHINGS_SYNC_COMMIT` ARG (digest-pinned) with the version extracted from the adjacent `# withings-sync vX.Y.Z` comment, using `github-tags`

## What Renovate now covers

| Dependency | Manager | Datasource |
|---|---|---|
| GitHub Actions (all workflows) | `github-actions` (default) | `github-releases` |
| `python:3.14-slim-bookworm` base image | `dockerfile` (default) | `docker` |
| `krallin/tini` | `regex` (custom) | `github-releases` |
| `jaroslawhartman/withings-sync` | `regex` (custom) | `github-tags` |

## Test plan
- [ ] Verify Renovate Dashboard issue is updated with the new detected dependencies
- [ ] Confirm a dry-run (`renovate --dry-run`) detects `krallin/tini` and `jaroslawhartman/withings-sync`
- [ ] Validate that withings-sync PRs update both the version comment and the commit SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)