### PR TITLE
Emit structured JSON logs for Datadog compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,10 @@ FROM python:3.14-slim-bookworm
 
 ARG TINI_VERSION=v0.19.0
 
-# Install tini for proper PID 1 signal handling, and libxml2/libxslt1.1 as
-# runtime dependencies for the lxml Python package.
+# Install tini for proper PID 1 signal handling, jq for structured JSON logging,
+# and libxml2/libxslt1.1 as runtime dependencies for the lxml Python package.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl libxml2 libxslt1.1 && \
+    apt-get install -y --no-install-recommends curl jq libxml2 libxslt1.1 && \
     curl -fsSL "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini" -o /tini && \
     chmod +x /tini && \
     apt-get purge -y --auto-remove curl && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,36 +5,67 @@ set -euo pipefail
 SYNC_INTERVAL="${SYNC_INTERVAL:-21600}"
 DATA_DIR="${DATA_DIR:-/data}"
 
+if ! command -v jq &>/dev/null; then
+    echo "FATAL: jq is not installed -- structured logging requires jq" >&2
+    exit 1
+fi
+
+# Emit a structured JSON log line to stdout (requires jq).
+# Datadog auto-parses JSON logs using the reserved attributes: timestamp, status, message.
+# Extra fields can be passed as jq --arg/--argjson flags after the message.
+# Falls back to plain-text on stderr if jq fails, so the container never dies silently.
+log() {
+    local status="$1" message="$2"
+    shift 2
+    if ! jq -nc \
+        --arg timestamp "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+        --arg status "$status" \
+        --arg message "$message" \
+        "$@" \
+        '$ARGS.named' 2>/dev/null
+    then
+        echo "LOG_FALLBACK: status=$status message=$message" >&2
+    fi
+}
+
 # Validate SYNC_INTERVAL is a positive integer (zero is not permitted).
 if ! [[ "${SYNC_INTERVAL}" =~ ^[1-9][0-9]*$ ]]; then
-    echo "Error: SYNC_INTERVAL must be a positive integer, got '${SYNC_INTERVAL}'"
+    log "error" "SYNC_INTERVAL must be a positive integer" --arg sync_interval "${SYNC_INTERVAL}"
     exit 1
 fi
 
 # Validate DATA_DIR exists and is writable.
 if [ ! -d "${DATA_DIR}" ]; then
-    echo "Error: DATA_DIR '${DATA_DIR}' does not exist"
+    log "error" "DATA_DIR does not exist" --arg data_dir "${DATA_DIR}"
     exit 1
 fi
 if [ ! -w "${DATA_DIR}" ]; then
-    echo "Error: DATA_DIR '${DATA_DIR}' is not writable"
+    log "error" "DATA_DIR is not writable" --arg data_dir "${DATA_DIR}"
     exit 1
 fi
 
 export HOME="${DATA_DIR}"
 
-echo "$(date): Container started (sync interval: ${SYNC_INTERVAL}s, data dir: ${DATA_DIR})"
+log "info" "Container started" \
+    --argjson sync_interval "${SYNC_INTERVAL}" \
+    --arg data_dir "${DATA_DIR}"
 
 while true;
 do
-    echo "$(date): Starting withings-sync"
+    log "info" "Starting withings-sync"
     # Suppress log lines containing 'garmin_password' to reduce credential exposure.
     # Use sed instead of grep -v to avoid exit code 1 when all lines are filtered,
     # which would cause false error reports under pipefail.
-    if ! /usr/local/bin/withings-sync -v 2>&1 | sed '/garmin_password/d'
+    # Each output line is wrapped in JSON via the log function.
+    # Under pipefail, the pipeline returns the rightmost non-zero exit code.
+    # sed always exits 0. The while-read subshell exits 0 when log (jq) succeeds
+    # on every line, so in normal operation withings-sync's exit code propagates.
+    if ! /usr/local/bin/withings-sync -v 2>&1 \
+        | sed '/garmin_password/d' \
+        | while IFS= read -r line; do log "info" "$line" --arg source "withings-sync"; done
     then
-        echo "$(date): Error occurred during withings-sync"
+        log "error" "withings-sync failed" --argjson exit_code "$?"
     fi
-    echo "$(date): Finished withings-sync, next run in ${SYNC_INTERVAL}s"
+    log "info" "Finished withings-sync" --argjson next_run_seconds "${SYNC_INTERVAL}"
     sleep "${SYNC_INTERVAL}"
 done


### PR DESCRIPTION
## Summary
- Add `jq` to the runtime Docker image
- Replace all `echo` log statements with a `log()` helper that emits JSON lines using Datadog's reserved attributes (`timestamp`, `status`, `message`)
- The helper uses `jq -nc` with `$ARGS.named` so all values are properly escaped — no manual JSON string construction
- Extra fields (`sync_interval`, `data_dir`, `next_run_seconds`) are passed as typed `--arg`/`--argjson` flags
- `withings-sync` stdout/stderr is also wrapped line-by-line in JSON with `source: "withings-sync"` for filtering
- All container output is now valid JSON lines, so Datadog auto-parses without pipeline configuration

## Example output
```json
{"timestamp":"2026-02-11T10:00:00Z","status":"info","message":"Container started","sync_interval":21600,"data_dir":"/data"}
{"timestamp":"2026-02-11T10:00:00Z","status":"info","message":"Starting withings-sync"}
{"timestamp":"2026-02-11T10:00:00Z","status":"info","message":"Syncing measurements...","source":"withings-sync"}
{"timestamp":"2026-02-11T10:00:01Z","status":"error","message":"withings-sync failed"}
{"timestamp":"2026-02-11T10:00:01Z","status":"info","message":"Finished withings-sync","next_run_seconds":21600}
```

## Test plan
- [ ] Build image and verify `jq` is present: `docker run --rm <image> jq --version`
- [ ] Run container with valid config and confirm all stdout is valid JSON lines
- [ ] Run with invalid `SYNC_INTERVAL=abc` and confirm structured error + exit 1
- [ ] Run with non-existent `DATA_DIR` and confirm structured error + exit 1
- [ ] Verify `withings-sync` output lines include `"source":"withings-sync"` field
- [ ] Verify Datadog Log Explorer auto-parses the JSON lines without a custom pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)