### PR TITLE
Add build CI smoke test to verify image before push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,32 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Build and load into the local Docker daemon for smoke testing
+      # before pushing to the registry.
+      - name: Build
+        uses: docker/build-push-action@v6
+        with:
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Verify the image boots and critical runtime dependencies work.
+      - name: Smoke test
+        run: |
+          IMAGE=$(echo "$TAGS" | head -n1)
+          if [ -z "$IMAGE" ]; then
+            echo "::error::Docker metadata tags output is empty. Check the 'Docker meta' step."
+            exit 1
+          fi
+          docker run --rm "$IMAGE" withings-sync --help
+          docker run --rm "$IMAGE" python -c "import lxml.etree"
+          docker run --rm "$IMAGE" jq --version
+          docker run --rm "$IMAGE" test -x /entrypoint.sh
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+
       - name: Docker Login
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
@@ -39,10 +65,13 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
+      # Push the exact image that was built and tested, not a cache-based
+      # rebuild, to guarantee artifact identity.
+      - name: Push
+        if: github.event_name != 'pull_request'
+        run: |
+          while IFS= read -r tag; do
+            [ -n "$tag" ] && docker push "$tag"
+          done <<< "$TAGS"
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Summary

Closes #65.

- Split the single "Build and push" step into **Build**, **Smoke test**, and **Push**
- The image is loaded into the local Docker daemon (`load: true`), smoke tested, then pushed via `docker push` to guarantee the tested artifact is exactly what reaches the registry
- Added GHA cache (`type=gha`) for layer reuse across workflow runs

### Smoke test coverage

| Check | What it validates |
|-------|-------------------|
| `withings-sync --help` | Binary is installed and on PATH |
| `python -c "import lxml.etree"` | Runtime shared libraries (`libxml2`, `libxslt1.1`) link correctly |
| `jq --version` | `jq` is available (required by `entrypoint.sh` for structured logging) |
| `test -x /entrypoint.sh` | Entrypoint script is present and executable |

### Design decisions

- **`docker push` instead of a second `build-push-action`**: A second `build-push-action` invocation would rebuild from cache, which is not guaranteed to produce a byte-identical image. Using `docker push` directly ensures the exact tested image is what gets published.
- **Image tag derived from metadata output**: The smoke test reads `TAGS` from `steps.meta.outputs.tags` via env var rather than hardcoding the registry path, avoiding drift if the `images` input changes.
- **Empty-tag guard**: Validates metadata output is non-empty before running `docker run`, surfacing a clear `::error::` annotation instead of an opaque Docker reference error.

## Test plan

- [ ] Verify the workflow runs successfully on this PR (build + smoke test, no push)
- [ ] Verify a tagged release still builds, tests, and pushes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)